### PR TITLE
Adds customizable CacheProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ let expiration = Date()
 TinyCache.cache(key, value: value, expiration: expiration)
 ```
 
-## Custom CacheProvider
+### Custom CacheProvider
 
 For custom cache logic, create an object that conforms to `CacheProvidable` and implement:
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ let expiration = Date()
 TinyCache.cache(key, value: value, expiration: expiration)
 ```
 
+## Custom CacheProvider
+
+For custom cache logic, create an object that conforms to `CacheProvidable` and implement:
+
+```swift
+func set(key: String, value: Codable, expiresAt: Date)
+func get<T: Codable>(_ type: T.Type, key: String) -> T?
+func clear()
+```
+
+To set your new provider, call `configure`:
+
+```swift
+TinyCache.configure(provider: MyCustomCacheProvider())
+```
+
+Calling `configure` immediately clears the current cache and sets your object as the default cache provider.
+
 ## License
 
 [MIT License](http://opensource.org/licenses/MIT).

--- a/Sources/TinyCache/Providers/CacheProvidable.swift
+++ b/Sources/TinyCache/Providers/CacheProvidable.swift
@@ -1,0 +1,20 @@
+//
+//  File.swift
+//  
+//
+//  Created by Cody Kerns on 5/17/22.
+//
+
+import Foundation
+
+public protocol CacheProvidable {
+
+    func set(key: String, value: Codable, expiresAt: Date)
+    func get<T: Codable>(_ type: T.Type, key: String) -> T?
+    func clear()
+
+}
+
+public class CacheProvider {
+
+}

--- a/Sources/TinyCache/Providers/CacheProvidable.swift
+++ b/Sources/TinyCache/Providers/CacheProvidable.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  CacheProvidable.swift
+//  TinyCache
 //
 //  Created by Cody Kerns on 5/17/22.
 //

--- a/Sources/TinyCache/Providers/MemoryProvider.swift
+++ b/Sources/TinyCache/Providers/MemoryProvider.swift
@@ -1,0 +1,46 @@
+//
+//  File.swift
+//  
+//
+//  Created by Cody Kerns on 5/17/22.
+//
+
+import Foundation
+
+public extension CacheProvider {
+    class MemoryProvider: CacheProvidable {
+        fileprivate var cache: [String: MemoryCacheValue] = [:]
+
+        public func set(key: String, value: Codable, expiresAt: Date) {
+            let val = MemoryCacheValue(value: value, expiresAt: expiresAt)
+            cache[key] = val
+        }
+
+        public func get<T: Codable>(_ type: T.Type, key: String) -> T? {
+            removeExpiredValues()
+            let obj = cache.first(where: {$0.key == key})
+            return obj?.value.value as? T
+        }
+
+        public func clear() {
+            cache.removeAll()
+        }
+    }
+}
+
+extension CacheProvider.MemoryProvider {
+    private func removeExpiredValues() {
+        for val in cache {
+            if Date() > val.value.expiresAt {
+                cache.removeValue(forKey: val.key)
+            }
+        }
+    }
+}
+
+extension CacheProvider.MemoryProvider {
+    struct MemoryCacheValue {
+        var value: Codable
+        var expiresAt: Date
+    }
+}

--- a/Sources/TinyCache/Providers/MemoryProvider.swift
+++ b/Sources/TinyCache/Providers/MemoryProvider.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  MemoryProvider.swift
+//  TinyCache
 //
 //  Created by Cody Kerns on 5/17/22.
 //

--- a/Tests/TinyCacheTests/TinyCacheTests.swift
+++ b/Tests/TinyCacheTests/TinyCacheTests.swift
@@ -53,4 +53,17 @@ final class TinyCacheTests: XCTestCase {
         TinyCache.cache(key, value: value, expiration: Date().add(minutes: -1))
         XCTAssertNil(TinyCache.value(String.self, key: key))
     }
+
+    func testNewProviderIsEmpty() {
+        TinyCache.clear()
+
+        let key = "key"
+        let value = "value"
+
+        TinyCache.cache(key, value: value)
+        XCTAssertNotNil(TinyCache.value(String.self, key: key))
+
+        TinyCache.configure(provider: CacheProvider.MemoryProvider())
+        XCTAssertNil(TinyCache.value(String.self, key: key))
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new protocol and method to add custom cache provider logic.

## API Changes

- New `CacheProvidable` protocol
- Default `CacheProvider.MemoryProvider` for in-memory storage
- New `TinyCache.configure` method to configure custom cache providers